### PR TITLE
NativeSwitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ A modern, customizable switch component library for Jetpack Compose that provide
 
 ## ✨ Features
 
-- **Multiple Switch Variants**: 6 different switch styles to choose from
+- **Multiple Switch Variants**: 7 different switch styles to choose from
 - **Multiplatform Support**: Works on Android, iOS and Desktop
 - **Smooth Animations**: Fluid transitions with customizable duration and easing
 - **Highly Customizable**: Colors, shapes, sizes, and content can be tailored to your needs
 - **Jetpack Compose Native**: Built specifically for Compose with modern UI patterns
 - **Lightweight**: Minimal dependencies and optimized performance
 - **Material Design 3**: Follows Material Design guidelines and theming
+- **Platform Native Switches**: Use platform-specific native switch implementations
 
 ### Available Switch Types
 
@@ -31,6 +32,7 @@ A modern, customizable switch component library for Jetpack Compose that provide
 5. **CustomISwitch** - iOS-style switch with custom content
 6. **CustomSwitch** - Fully customizable switch with custom content
 7. **SquareSwitch** - Modern square-style switch
+8. **NativeSwitch** - Platform-specific native switch implementation (Material3 on Android, UIKit on iOS)
 
 ## 🛠 Technology Stack
 
@@ -234,6 +236,19 @@ SquareSwitch(
 )
 ```
 
+### NativeSwitch
+
+```kotlin
+var checked by rememberSaveable { mutableStateOf(false) }
+
+NativeSwitch(
+    checked = checked,
+    onCheckedChange = { checked = it },
+    modifier = Modifier.padding(horizontal = 16.dp),
+    enabled = true
+)
+```
+
 ## 🎨 Customization
 
 ### Common Parameters
@@ -312,3 +327,5 @@ limitations under the License.
 ---
 
 **Made with ❤️ by [Muaz KADAN](https://github.com/muazkadan)** | [LinkedIn](https://www.linkedin.com/in/muaz-kadan-727911107/)
+
+

--- a/switchycompose/multiplatform/src/androidMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.android.kt
+++ b/switchycompose/multiplatform/src/androidMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.android.kt
@@ -1,0 +1,20 @@
+package dev.muazkadan.switchycompose
+
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+actual fun NativeSwitch(
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier,
+    enabled: Boolean
+) {
+    Switch(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier,
+        enabled = enabled
+    )
+}

--- a/switchycompose/multiplatform/src/commonMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.kt
+++ b/switchycompose/multiplatform/src/commonMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.kt
@@ -1,0 +1,20 @@
+package dev.muazkadan.switchycompose
+
+import androidx.compose.runtime.Composable
+
+/**
+ * A composable function that provides a platform-specific native switch implementation.
+ * On Android, it uses Material3's Switch component, while on iOS, it uses UIKit's UISwitch.
+ *
+ * @param checked The current checked state of the switch.
+ * @param onCheckedChange Callback invoked when the switch state changes. If null, the switch will be non-interactive.
+ * @param modifier The modifier to be applied to the switch.
+ * @param enabled Whether the switch is enabled and can be interacted with. Default is true.
+ */
+@Composable
+expect fun NativeSwitch(
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)? = null,
+    modifier: androidx.compose.ui.Modifier = androidx.compose.ui.Modifier,
+    enabled: Boolean = true,
+)

--- a/switchycompose/multiplatform/src/iosMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.ios.kt
+++ b/switchycompose/multiplatform/src/iosMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.ios.kt
@@ -1,0 +1,73 @@
+package dev.muazkadan.switchycompose
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.UIKitInteropProperties
+import androidx.compose.ui.viewinterop.UIKitView
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCAction
+import platform.UIKit.UISwitch
+import platform.UIKit.UIControlEventValueChanged
+import platform.darwin.NSObject
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+@Composable
+actual fun NativeSwitch(
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier,
+    enabled: Boolean
+) {
+    UIKitView(
+        factory = {
+            val switch = UISwitch()
+
+            // Create a target object to handle the callback
+            val target = object : NSObject() {
+                @ObjCAction
+                fun switchValueChanged() {
+                    onCheckedChange?.invoke(switch.isOn())
+                }
+            }
+
+            // Set initial state
+            switch.setOn(checked, animated = false)
+            switch.setEnabled(enabled)
+
+            // Size the switch to fit its content
+            switch.sizeToFit()
+
+            // Add target-action for value changes
+            onCheckedChange?.let {
+                switch.addTarget(
+                    target = target,
+                    action = platform.objc.sel_registerName("switchValueChanged"),
+                    forControlEvents = UIControlEventValueChanged
+                )
+            }
+
+            switch
+        },
+        modifier = modifier
+            // Provide default intrinsic size for UISwitch (51x31 points)
+            .size(width = 51.dp, height = 31.dp),
+        update = { view ->
+            val switch = view
+
+            // Update switch state if it differs from current state
+            if (switch.isOn() != checked) {
+                switch.setOn(checked, animated = true)
+            }
+
+            // Update enabled state
+            switch.setEnabled(enabled)
+        },
+        properties = UIKitInteropProperties(
+            isInteractive = true,
+            isNativeAccessibilityEnabled = true
+        )
+    )
+}

--- a/switchycompose/multiplatform/src/jvmMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.jvm.kt
+++ b/switchycompose/multiplatform/src/jvmMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.jvm.kt
@@ -1,0 +1,20 @@
+package dev.muazkadan.switchycompose
+
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+actual fun NativeSwitch(
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier,
+    enabled: Boolean
+) {
+    Switch(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier,
+        enabled = enabled
+    )
+}


### PR DESCRIPTION
This PR introduces a new `NativeSwitch` component that uses truly native switch controls on each supported platform (Android & iOS).

The component: 
- Uses Material3's Switch component on Android

- Uses UIKit's UISwitch component on iOS through Compose Multiplatform interop