### PR TITLE
add experimental WASM support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ import org.gradle.kotlin.dsl.implementation
 import org.gradle.kotlin.dsl.project
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
@@ -33,6 +34,26 @@ kotlin {
     }
     
     jvm("desktop")
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        outputModuleName = "composeApp"
+        browser {
+            val rootDirPath = project.rootDir.path
+            val projectDirPath = project.projectDir.path
+            commonWebpackConfig {
+                outputFileName = "composeApp.js"
+                devServer = (devServer ?: KotlinWebpackConfig.DevServer()).apply {
+                    static = (static ?: mutableListOf()).apply {
+                        // Serve sources to debug inside browser
+                        add(rootDirPath)
+                        add(projectDirPath)
+                    }
+                }
+            }
+        }
+        binaries.executable()
+    }
     
     sourceSets {
         val desktopMain by getting

--- a/app/src/wasmJsMain/kotlin/dev/muazkadan/switchycomposedemo/main.kt
+++ b/app/src/wasmJsMain/kotlin/dev/muazkadan/switchycomposedemo/main.kt
@@ -1,0 +1,12 @@
+package dev.muazkadan.switchycomposedemo
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.ComposeViewport
+import kotlinx.browser.document
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    ComposeViewport(document.body!!) {
+        App()
+    }
+}

--- a/app/src/wasmJsMain/resources/index.html
+++ b/app/src/wasmJsMain/resources/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SwitchyComposeDemo</title>
+    <link type="text/css" rel="stylesheet" href="styles.css">
+    <script type="application/javascript" src="composeApp.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/app/src/wasmJsMain/resources/styles.css
+++ b/app/src/wasmJsMain/resources/styles.css
@@ -1,0 +1,7 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,6 @@ pluginManagement {
     }
 }
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()

--- a/switchycompose/multiplatform/build.gradle.kts
+++ b/switchycompose/multiplatform/build.gradle.kts
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalWasmDsl::class)
+
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -22,6 +25,9 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_11)
         }
     }
+
+    wasmJs { browser() }
+
     listOf(
         iosX64(),
         iosArm64(),
@@ -73,9 +79,10 @@ mavenPublishing {
 
     // Only sign if signing properties are available (e.g., for Maven Central)
     // This prevents signing issues when building on JitPack
-    if (project.hasProperty("signing.keyId") && 
-        project.hasProperty("signing.password") && 
-        project.hasProperty("signing.secretKeyRingFile")) {
+    if (project.hasProperty("signing.keyId") &&
+        project.hasProperty("signing.password") &&
+        project.hasProperty("signing.secretKeyRingFile")
+    ) {
         signAllPublications()
     }
 

--- a/switchycompose/multiplatform/src/wasmJsMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.wasmJs.kt
+++ b/switchycompose/multiplatform/src/wasmJsMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.wasmJs.kt
@@ -1,0 +1,21 @@
+package dev.muazkadan.switchycompose
+
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+actual fun NativeSwitch(
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier,
+    enabled: Boolean
+) {
+    // For Wasm/JS, we use Material3's Switch component which works well in web contexts
+    Switch(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier,
+        enabled = enabled
+    )
+}


### PR DESCRIPTION
This PR adds WebAssembly (WASM) support to Switchy Compose, enabling the library to be used in web browsers via Kotlin/Wasm.