### PR TITLE
Add UI tests for Switch composables

### DIFF
--- a/switchycompose/multiplatform/src/commonTest/kotlin/dev/muazkadan/switchycompose/CustomISwitchTest.kt
+++ b/switchycompose/multiplatform/src/commonTest/kotlin/dev/muazkadan/switchycompose/CustomISwitchTest.kt
@@ -1,0 +1,260 @@
+package dev.muazkadan.switchycompose
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class CustomISwitchTest {
+
+    private val switchTag = "customISwitch"
+
+    @Test
+    fun testInitialStateUnchecked() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                CustomISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false,
+                    onCheckedChange = { },
+                    positiveContent = {
+                        Text("ON")
+                    },
+                    negativeContent = {
+                        Text("OFF")
+                    }
+                )
+            }
+        }
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsOff()
+    }
+
+    @Test
+    fun testInitialStateChecked() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                CustomISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = true,
+                    onCheckedChange = { },
+                    positiveContent = {
+                        Text("ON")
+                    },
+                    negativeContent = {
+                        Text("OFF")
+                    }
+                )
+            }
+        }
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsOn()
+    }
+
+    @Test
+    fun testToggle() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                CustomISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = { checkedState.value = it },
+                    positiveContent = {
+                        Text("ON")
+                    },
+                    negativeContent = {
+                        Text("OFF")
+                    }
+                )
+            }
+        }
+
+        // Initial state: Off
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+
+        // Click to turn On
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+
+        // Click to turn Off
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+    }
+
+    @Test
+    fun testOnCheckedChangeCallback() = runComposeUiTest {
+        var callbackValue: Boolean? = null
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                CustomISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        callbackValue = it
+                        checkedState.value = it
+                    },
+                    positiveContent = {
+                        Text("ON")
+                    },
+                    negativeContent = {
+                        Text("OFF")
+                    }
+                )
+            }
+        }
+
+        // Click to toggle
+        onNodeWithTag(switchTag).performClick()
+        assertEquals(true, callbackValue)
+
+        // Click again to toggle back
+        onNodeWithTag(switchTag).performClick()
+        assertEquals(false, callbackValue)
+    }
+
+    @Test
+    fun testDisabledStateUnchecked() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        var callbackCalled = false
+        setContent {
+            MaterialTheme {
+                CustomISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        checkedState.value = it
+                        callbackCalled = true
+                    },
+                    enabled = false,
+                    positiveContent = {
+                        Text("ON")
+                    },
+                    negativeContent = {
+                        Text("OFF")
+                    }
+                )
+            }
+        }
+
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsNotEnabled().assertIsOff()
+
+        // Attempt to click, should not change state or call callback
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+        assertEquals(false, callbackCalled)
+    }
+
+    @Test
+    fun testDisabledStateChecked() = runComposeUiTest {
+        val checkedState = mutableStateOf(true)
+        var callbackCalled = false
+        setContent {
+            MaterialTheme {
+                CustomISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        checkedState.value = it
+                        callbackCalled = true
+                    },
+                    enabled = false,
+                    positiveContent = {
+                        Text("ON")
+                    },
+                    negativeContent = {
+                        Text("OFF")
+                    }
+                )
+            }
+        }
+
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsNotEnabled().assertIsOn()
+
+        // Attempt to click, should not change state or call callback
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+        assertEquals(false, callbackCalled)
+    }
+
+    @Test
+    fun testNullOnCheckedChangeCallback() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                CustomISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false,
+                    onCheckedChange = null,
+                    positiveContent = {
+                        Text("ON")
+                    },
+                    negativeContent = {
+                        Text("OFF")
+                    }
+                )
+            }
+        }
+
+        // Should be displayed, but we don't use assertIsOff() because
+        // without onCheckedChange, the node doesn't have toggleable semantics
+        onNodeWithTag(switchTag).assertIsDisplayed()
+
+        // Attempt to click - this should effectively be a no-op
+        // since the switch has no callback to handle the click
+        onNodeWithTag(switchTag).performClick()
+
+        // The switch should still be displayed
+        // Note: We can't use assertIsOff() here because there are no toggleable semantics
+        // when onCheckedChange is null
+        onNodeWithTag(switchTag).assertIsDisplayed()
+    }
+
+    @Test
+    fun testCustomIconContent() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                CustomISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = { checkedState.value = it },
+                    positiveContent = {
+                        Icon(Icons.Default.CheckCircle, contentDescription = null)
+                    },
+                    negativeContent = {
+                        Icon(Icons.Default.RadioButtonUnchecked, contentDescription = null)
+                    }
+                )
+            }
+        }
+
+        // Initial state: Off
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+
+        // Click to turn On
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+    }
+}

--- a/switchycompose/multiplatform/src/commonTest/kotlin/dev/muazkadan/switchycompose/CustomSwitchTest.kt
+++ b/switchycompose/multiplatform/src/commonTest/kotlin/dev/muazkadan/switchycompose/CustomSwitchTest.kt
@@ -1,0 +1,287 @@
+package dev.muazkadan.switchycompose
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class CustomSwitchTest {
+
+    private val switchTag = "customSwitch"
+
+    @Test
+    fun testInitialStateUnchecked() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                CustomSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false,
+                    onCheckedChange = { },
+                    positiveContent = {
+                        Text("YES")
+                    },
+                    negativeContent = {
+                        Text("NO")
+                    }
+                )
+            }
+        }
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsOff()
+    }
+
+    @Test
+    fun testInitialStateChecked() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                CustomSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = true,
+                    onCheckedChange = { },
+                    positiveContent = {
+                        Text("YES")
+                    },
+                    negativeContent = {
+                        Text("NO")
+                    }
+                )
+            }
+        }
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsOn()
+    }
+
+    @Test
+    fun testToggle() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                CustomSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = { checkedState.value = it },
+                    positiveContent = {
+                        Text("YES")
+                    },
+                    negativeContent = {
+                        Text("NO")
+                    }
+                )
+            }
+        }
+
+        // Initial state: Off
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+
+        // Click to turn On
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+
+        // Click to turn Off
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+    }
+
+    @Test
+    fun testOnCheckedChangeCallback() = runComposeUiTest {
+        var callbackValue: Boolean? = null
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                CustomSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        callbackValue = it
+                        checkedState.value = it
+                    },
+                    positiveContent = {
+                        Text("YES")
+                    },
+                    negativeContent = {
+                        Text("NO")
+                    }
+                )
+            }
+        }
+
+        // Click to toggle
+        onNodeWithTag(switchTag).performClick()
+        assertEquals(true, callbackValue)
+
+        // Click again to toggle back
+        onNodeWithTag(switchTag).performClick()
+        assertEquals(false, callbackValue)
+    }
+
+    @Test
+    fun testDisabledStateUnchecked() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        var callbackCalled = false
+        setContent {
+            MaterialTheme {
+                CustomSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        checkedState.value = it
+                        callbackCalled = true
+                    },
+                    enabled = false,
+                    positiveContent = {
+                        Text("YES")
+                    },
+                    negativeContent = {
+                        Text("NO")
+                    }
+                )
+            }
+        }
+
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsNotEnabled().assertIsOff()
+
+        // Attempt to click, should not change state or call callback
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+        assertEquals(false, callbackCalled)
+    }
+
+    @Test
+    fun testDisabledStateChecked() = runComposeUiTest {
+        val checkedState = mutableStateOf(true)
+        var callbackCalled = false
+        setContent {
+            MaterialTheme {
+                CustomSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        checkedState.value = it
+                        callbackCalled = true
+                    },
+                    enabled = false,
+                    positiveContent = {
+                        Text("YES")
+                    },
+                    negativeContent = {
+                        Text("NO")
+                    }
+                )
+            }
+        }
+
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsNotEnabled().assertIsOn()
+
+        // Attempt to click, should not change state or call callback
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+        assertEquals(false, callbackCalled)
+    }
+
+    @Test
+    fun testNullOnCheckedChangeCallback() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                CustomSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false,
+                    onCheckedChange = null,
+                    positiveContent = {
+                        Text("YES")
+                    },
+                    negativeContent = {
+                        Text("NO")
+                    }
+                )
+            }
+        }
+
+        // Should be displayed
+        // Note: We can't use assertIsOff() because the component doesn't have toggleable
+        // semantics when onCheckedChange is null
+        onNodeWithTag(switchTag).assertIsDisplayed()
+
+        // Click should be a no-op since callback is null
+        onNodeWithTag(switchTag).performClick()
+
+        // Should still be displayed after click
+        onNodeWithTag(switchTag).assertIsDisplayed()
+    }
+
+    @Test
+    fun testCustomIconContent() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                CustomSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = { checkedState.value = it },
+                    positiveContent = {
+                        Icon(Icons.Default.Star, contentDescription = null)
+                    },
+                    negativeContent = {
+                        Icon(Icons.Default.StarBorder, contentDescription = null)
+                    }
+                )
+            }
+        }
+
+        // Initial state: Off
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+
+        // Click to turn On
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+    }
+
+    @Test
+    fun testMixedContentTypes() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                CustomSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = { checkedState.value = it },
+                    positiveContent = {
+                        Icon(Icons.Default.Star, contentDescription = null)
+                    },
+                    negativeContent = {
+                        Text("OFF")
+                    }
+                )
+            }
+        }
+
+        // Initial state: Off
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+
+        // Click to turn On
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+    }
+}

--- a/switchycompose/multiplatform/src/commonTest/kotlin/dev/muazkadan/switchycompose/IconISwitchTest.kt
+++ b/switchycompose/multiplatform/src/commonTest/kotlin/dev/muazkadan/switchycompose/IconISwitchTest.kt
@@ -1,0 +1,210 @@
+package dev.muazkadan.switchycompose
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class IconISwitchTest {
+
+    private val switchTag = "iconISwitch"
+
+    @Test
+    fun testInitialStateUnchecked() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                IconISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false,
+                    onCheckedChange = { }
+                )
+            }
+        }
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsOff()
+    }
+
+    @Test
+    fun testInitialStateChecked() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                IconISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = true,
+                    onCheckedChange = { }
+                )
+            }
+        }
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsOn()
+    }
+
+    @Test
+    fun testToggle() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                IconISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = { checkedState.value = it }
+                )
+            }
+        }
+
+        // Initial state: Off
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+
+        // Click to turn On
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+
+        // Click to turn Off
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+    }
+
+    @Test
+    fun testOnCheckedChangeCallback() = runComposeUiTest {
+        var callbackValue: Boolean? = null
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                IconISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        callbackValue = it
+                        checkedState.value = it
+                    }
+                )
+            }
+        }
+
+        // Click to toggle
+        onNodeWithTag(switchTag).performClick()
+        assertEquals(true, callbackValue)
+
+        // Click again to toggle back
+        onNodeWithTag(switchTag).performClick()
+        assertEquals(false, callbackValue)
+    }
+
+    @Test
+    fun testDisabledStateUnchecked() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        var callbackCalled = false
+        setContent {
+            MaterialTheme {
+                IconISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        checkedState.value = it
+                        callbackCalled = true
+                    },
+                    enabled = false
+                )
+            }
+        }
+
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsNotEnabled().assertIsOff()
+
+        // Attempt to click, should not change state or call callback
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+        assertEquals(false, callbackCalled)
+    }
+
+    @Test
+    fun testDisabledStateChecked() = runComposeUiTest {
+        val checkedState = mutableStateOf(true)
+        var callbackCalled = false
+        setContent {
+            MaterialTheme {
+                IconISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        checkedState.value = it
+                        callbackCalled = true
+                    },
+                    enabled = false
+                )
+            }
+        }
+
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsNotEnabled().assertIsOn()
+
+        // Attempt to click, should not change state or call callback
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+        assertEquals(false, callbackCalled)
+    }
+
+    @Test
+    fun testNullOnCheckedChangeCallback() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                IconISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false,
+                    onCheckedChange = null
+                )
+            }
+        }
+
+        // Should be displayed
+        // Note: We can't use assertIsOff() because the component doesn't have toggleable
+        // semantics when onCheckedChange is null
+        onNodeWithTag(switchTag).assertIsDisplayed()
+
+        // Click should be a no-op since callback is null
+        onNodeWithTag(switchTag).performClick()
+
+        // Should still be displayed after click
+        onNodeWithTag(switchTag).assertIsDisplayed()
+    }
+
+    @Test
+    fun testCustomIcons() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                IconISwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = { checkedState.value = it },
+                    positiveIcon = Icons.Default.Favorite,
+                    negativeIcon = Icons.Default.FavoriteBorder
+                )
+            }
+        }
+
+        // Initial state: Off
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+
+        // Click to turn On
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+    }
+}

--- a/switchycompose/multiplatform/src/commonTest/kotlin/dev/muazkadan/switchycompose/NativeSwitchTest.kt
+++ b/switchycompose/multiplatform/src/commonTest/kotlin/dev/muazkadan/switchycompose/NativeSwitchTest.kt
@@ -1,0 +1,199 @@
+package dev.muazkadan.switchycompose
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class NativeSwitchTest {
+
+    private val switchTag = "nativeSwitch"
+
+    @Test
+    fun testInitialStateUnchecked() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NativeSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false,
+                    onCheckedChange = { }
+                )
+            }
+        }
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsOff()
+    }
+
+    @Test
+    fun testInitialStateChecked() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NativeSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = true,
+                    onCheckedChange = { }
+                )
+            }
+        }
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsOn()
+    }
+
+    @Test
+    fun testToggle() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                NativeSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = { checkedState.value = it }
+                )
+            }
+        }
+
+        // Initial state: Off
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+
+        // Click to turn On
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+
+        // Click to turn Off
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+    }
+
+    @Test
+    fun testOnCheckedChangeCallback() = runComposeUiTest {
+        var callbackValue: Boolean? = null
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                NativeSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        callbackValue = it
+                        checkedState.value = it
+                    }
+                )
+            }
+        }
+
+        // Click to toggle
+        onNodeWithTag(switchTag).performClick()
+        assertEquals(true, callbackValue)
+
+        // Click again to toggle back
+        onNodeWithTag(switchTag).performClick()
+        assertEquals(false, callbackValue)
+    }
+
+    @Test
+    fun testDisabledStateUnchecked() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        var callbackCalled = false
+        setContent {
+            MaterialTheme {
+                NativeSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        checkedState.value = it
+                        callbackCalled = true
+                    },
+                    enabled = false
+                )
+            }
+        }
+
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsNotEnabled().assertIsOff()
+
+        // Attempt to click, should not change state or call callback
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+        assertEquals(false, callbackCalled)
+    }
+
+    @Test
+    fun testDisabledStateChecked() = runComposeUiTest {
+        val checkedState = mutableStateOf(true)
+        var callbackCalled = false
+        setContent {
+            MaterialTheme {
+                NativeSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        checkedState.value = it
+                        callbackCalled = true
+                    },
+                    enabled = false
+                )
+            }
+        }
+
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsNotEnabled().assertIsOn()
+
+        // Attempt to click, should not change state or call callback
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+        assertEquals(false, callbackCalled)
+    }
+
+    @Test
+    fun testNullOnCheckedChangeCallback() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NativeSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false,
+                    onCheckedChange = null
+                )
+            }
+        }
+
+        // Should be displayed
+        // Note: We can't use assertIsOff() because the component doesn't have toggleable
+        // semantics when onCheckedChange is null
+        onNodeWithTag(switchTag).assertIsDisplayed()
+
+        // Click should be a no-op since callback is null
+        onNodeWithTag(switchTag).performClick()
+
+        // Should still be displayed after click
+        onNodeWithTag(switchTag).assertIsDisplayed()
+    }
+
+    @Test
+    fun testDefaultParameters() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NativeSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false
+                )
+            }
+        }
+
+        // Should be displayed with default parameters
+        // Note: We can't use assertIsOff() because the default implementation
+        // doesn't have toggleable semantics (onCheckedChange is null by default)
+        onNodeWithTag(switchTag).assertIsDisplayed()
+    }
+}

--- a/switchycompose/multiplatform/src/commonTest/kotlin/dev/muazkadan/switchycompose/SquareSwitchTest.kt
+++ b/switchycompose/multiplatform/src/commonTest/kotlin/dev/muazkadan/switchycompose/SquareSwitchTest.kt
@@ -1,0 +1,182 @@
+package dev.muazkadan.switchycompose
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class SquareSwitchTest {
+
+    private val switchTag = "squareSwitch"
+
+    @Test
+    fun testInitialStateUnchecked() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SquareSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false,
+                    onCheckedChange = { }
+                )
+            }
+        }
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsOff()
+    }
+
+    @Test
+    fun testInitialStateChecked() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SquareSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = true,
+                    onCheckedChange = { }
+                )
+            }
+        }
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsOn()
+    }
+
+    @Test
+    fun testToggle() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                SquareSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = { checkedState.value = it }
+                )
+            }
+        }
+
+        // Initial state: Off
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+
+        // Click to turn On
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+
+        // Click to turn Off
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+    }
+
+    @Test
+    fun testOnCheckedChangeCallback() = runComposeUiTest {
+        var callbackValue: Boolean? = null
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                SquareSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        callbackValue = it
+                        checkedState.value = it
+                    }
+                )
+            }
+        }
+
+        // Click to toggle
+        onNodeWithTag(switchTag).performClick()
+        assertEquals(true, callbackValue)
+
+        // Click again to toggle back
+        onNodeWithTag(switchTag).performClick()
+        assertEquals(false, callbackValue)
+    }
+
+    @Test
+    fun testDisabledStateUnchecked() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        var callbackCalled = false
+        setContent {
+            MaterialTheme {
+                SquareSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        checkedState.value = it
+                        callbackCalled = true
+                    },
+                    enabled = false
+                )
+            }
+        }
+
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsNotEnabled().assertIsOff()
+
+        // Attempt to click, should not change state or call callback
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+        assertEquals(false, callbackCalled)
+    }
+
+    @Test
+    fun testDisabledStateChecked() = runComposeUiTest {
+        val checkedState = mutableStateOf(true)
+        var callbackCalled = false
+        setContent {
+            MaterialTheme {
+                SquareSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        checkedState.value = it
+                        callbackCalled = true
+                    },
+                    enabled = false
+                )
+            }
+        }
+
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsNotEnabled().assertIsOn()
+
+        // Attempt to click, should not change state or call callback
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+        assertEquals(false, callbackCalled)
+    }
+
+    @Test
+    fun testNullOnCheckedChangeCallback() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SquareSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false,
+                    onCheckedChange = null
+                )
+            }
+        }
+
+        // Should be displayed
+        // Note: We can't use assertIsOff() because the component doesn't have toggleable
+        // semantics when onCheckedChange is null
+        onNodeWithTag(switchTag).assertIsDisplayed()
+
+        // Click should be a no-op since callback is null
+        onNodeWithTag(switchTag).performClick()
+
+        // Should still be displayed after click
+        onNodeWithTag(switchTag).assertIsDisplayed()
+    }
+}

--- a/switchycompose/multiplatform/src/commonTest/kotlin/dev/muazkadan/switchycompose/TextSwitchTest.kt
+++ b/switchycompose/multiplatform/src/commonTest/kotlin/dev/muazkadan/switchycompose/TextSwitchTest.kt
@@ -1,0 +1,207 @@
+package dev.muazkadan.switchycompose
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class TextSwitchTest {
+
+    private val switchTag = "textSwitch"
+
+    @Test
+    fun testInitialStateUnchecked() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TextSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false,
+                    onCheckedChange = { }
+                )
+            }
+        }
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsOff()
+    }
+
+    @Test
+    fun testInitialStateChecked() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TextSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = true,
+                    onCheckedChange = { }
+                )
+            }
+        }
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsOn()
+    }
+
+    @Test
+    fun testToggle() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                TextSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = { checkedState.value = it }
+                )
+            }
+        }
+
+        // Initial state: Off
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+
+        // Click to turn On
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+
+        // Click to turn Off
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+    }
+
+    @Test
+    fun testOnCheckedChangeCallback() = runComposeUiTest {
+        var callbackValue: Boolean? = null
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                TextSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        callbackValue = it
+                        checkedState.value = it
+                    }
+                )
+            }
+        }
+
+        // Click to toggle
+        onNodeWithTag(switchTag).performClick()
+        assertEquals(true, callbackValue)
+
+        // Click again to toggle back
+        onNodeWithTag(switchTag).performClick()
+        assertEquals(false, callbackValue)
+    }
+
+    @Test
+    fun testDisabledStateUnchecked() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        var callbackCalled = false
+        setContent {
+            MaterialTheme {
+                TextSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        checkedState.value = it
+                        callbackCalled = true
+                    },
+                    enabled = false
+                )
+            }
+        }
+
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsNotEnabled().assertIsOff()
+
+        // Attempt to click, should not change state or call callback
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+        assertEquals(false, callbackCalled)
+    }
+
+    @Test
+    fun testDisabledStateChecked() = runComposeUiTest {
+        val checkedState = mutableStateOf(true)
+        var callbackCalled = false
+        setContent {
+            MaterialTheme {
+                TextSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = {
+                        checkedState.value = it
+                        callbackCalled = true
+                    },
+                    enabled = false
+                )
+            }
+        }
+
+        onNodeWithTag(switchTag).assertIsDisplayed().assertIsNotEnabled().assertIsOn()
+
+        // Attempt to click, should not change state or call callback
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+        assertEquals(false, callbackCalled)
+    }
+
+    @Test
+    fun testNullOnCheckedChangeCallback() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                TextSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = false,
+                    onCheckedChange = null
+                )
+            }
+        }
+
+        // Should be displayed
+        // Note: We can't use assertIsOff() because the component doesn't have toggleable
+        // semantics when onCheckedChange is null
+        onNodeWithTag(switchTag).assertIsDisplayed()
+
+        // Click should be a no-op since callback is null
+        onNodeWithTag(switchTag).performClick()
+
+        // Should still be displayed after click
+        onNodeWithTag(switchTag).assertIsDisplayed()
+    }
+
+    @Test
+    fun testCustomTextLabels() = runComposeUiTest {
+        val checkedState = mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                TextSwitch(
+                    modifier = Modifier.testTag(switchTag),
+                    checked = checkedState.value,
+                    onCheckedChange = { checkedState.value = it },
+                    positiveText = "ON",
+                    negativeText = "OFF"
+                )
+            }
+        }
+
+        // Initial state: Off
+        onNodeWithTag(switchTag).assertIsOff()
+        assertEquals(false, checkedState.value)
+
+        // Click to turn On
+        onNodeWithTag(switchTag).performClick()
+        onNodeWithTag(switchTag).assertIsOn()
+        assertEquals(true, checkedState.value)
+    }
+}


### PR DESCRIPTION
This PR introduces a suite of UI tests for various Switch composables. The tests cover the following components:

- `SquareSwitch`
- `TextSwitch`
- `CustomSwitch`
- `NativeSwitch`
- `IconISwitch`
- `CustomISwitch`

**For each component, the tests verify:**
- Initial state (checked/unchecked) and display.
- Toggling functionality and state changes on click.
- Correct invocation and behavior of the `onCheckedChange` callback.
- Disabled state behavior (non-interactive, no state change, no callback invocation).
- Behavior when `onCheckedChange` is null (should be displayed but non-interactive).
- Specific features like custom text labels for `TextSwitch` and custom icon/content for `CustomSwitch`, `IconISwitch`, and `CustomISwitch`.

All tests are implemented using `runComposeUiTest` and standard Compose testing APIs.