### PR TITLE
refactored example App.kt 

### DIFF
--- a/app/src/commonMain/kotlin/dev/muazkadan/switchycomposedemo/App.kt
+++ b/app/src/commonMain/kotlin/dev/muazkadan/switchycomposedemo/App.kt
@@ -3,14 +3,10 @@ package dev.muazkadan.switchycomposedemo
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.icons.filled.Done
@@ -20,12 +16,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.lazy.grid.GridCells.Adaptive
 import dev.muazkadan.switchycompose.ColoredSwitch
@@ -51,7 +45,7 @@ internal fun App() {
             verticalArrangement = Arrangement.spacedBy(16.dp),
             contentPadding = PaddingValues(16.dp)
         ) {
-            item {
+            item(span = { GridItemSpan(2) }) {
                 Column(
                     modifier = Modifier.padding(8.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -115,7 +109,7 @@ internal fun App() {
                     )
                 }
             }
-            item(span = { GridItemSpan(2) }) {
+            item {
                 Column(
                     modifier = Modifier.padding(8.dp).fillMaxWidth(),
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -140,7 +134,7 @@ internal fun App() {
                     )
                 }
             }
-            item {
+            item(span = { GridItemSpan(2) }) {
                 Column(
                     modifier = Modifier.padding(8.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/commonMain/kotlin/dev/muazkadan/switchycomposedemo/App.kt
+++ b/app/src/commonMain/kotlin/dev/muazkadan/switchycomposedemo/App.kt
@@ -2,23 +2,32 @@ package dev.muazkadan.switchycomposedemo
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.lazy.grid.GridCells.Adaptive
 import dev.muazkadan.switchycompose.ColoredSwitch
 import dev.muazkadan.switchycompose.CustomISwitch
 import dev.muazkadan.switchycompose.CustomSwitch
@@ -32,151 +41,205 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 @Preview
-fun App() {
+internal fun App() {
     MaterialTheme {
-        var switchValue by rememberSaveable { mutableStateOf(false) }
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally
+        LazyVerticalGrid(
+            columns = Adaptive(minSize = 150.dp),
+            modifier = Modifier
+                .fillMaxSize(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            contentPadding = PaddingValues(16.dp)
         ) {
-            Spacer(
-                modifier = Modifier.size(16.dp)
-            )
-            Text(text = "TextSwitch")
-            TextSwitch(
-                modifier = Modifier
-                    .padding(horizontal = 16.dp),
-                checked = switchValue,
-                onCheckedChange = {
-                    switchValue = it
-                },
-            )
-            Spacer(
-                modifier = Modifier.size(16.dp)
-            )
-            Text(text = "ColoredSwitch")
-            ColoredSwitch(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                checked = switchValue,
-                onCheckedChange = {
-                    switchValue = it
-                },
-            )
-            Spacer(
-                modifier = Modifier.size(16.dp)
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly
-            ) {
-                Text(text = "ISwitch")
-                Text(text = "IconISwitch")
-                Text(text = "CustomISwitch")
-            }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly
-            ) {
-                ISwitch(
-                    checked = switchValue,
-                    onCheckedChange = {
-                        switchValue = it
-                    },
-                )
-                IconISwitch(
-                    checked = switchValue,
-                    onCheckedChange = {
-                        switchValue = it
-                    },
-                )
-                CustomISwitch(
-                    checked = switchValue,
-                    positiveContent = {
-                        Icon(
-                            imageVector = Icons.Default.Done,
-                            contentDescription = null
-                        )
-                    },
-                    negativeContent = {
-                        Text(text = "OFF")
-                    },
-                    onCheckedChange = {
-                        switchValue = it
-                    }
-                )
-            }
-            Spacer(
-                modifier = Modifier.size(16.dp)
-            )
-            Text(text = "CustomSwitch")
-            CustomSwitch(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                checked = switchValue,
-                onCheckedChange = {
-                    switchValue = it
-                },
-                positiveContent = {
-                    Icon(
-                        imageVector = Icons.Default.Done,
-                        contentDescription = null,
-                    )
-                },
-                negativeContent = {
-                    Text(
-                        "False"
+            item {
+                Column(
+                    modifier = Modifier.padding(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(text = "TextSwitch")
+                    var textSwitchValue by rememberSaveable { mutableStateOf(false) }
+                    TextSwitch(
+                        checked = textSwitchValue,
+                        onCheckedChange = {
+                            textSwitchValue = it
+                        },
                     )
                 }
-            )
-            Spacer(
-                modifier = Modifier.size(16.dp)
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly
-            ) {
-                Text(text = "Square Switch")
-                Text(text = "Native Switch")
             }
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly
-            ) {
-                SquareSwitch(
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp),
-                    checked = switchValue,
-                    onCheckedChange = {
-                        switchValue = it
-                    }
-                )
-                NativeSwitch(
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp),
-                    checked = switchValue,
-                    onCheckedChange = {
-                        switchValue = it
-                    }
-                )
-            }
-            Spacer(
-                modifier = Modifier.size(16.dp)
-            )
-            Text(text = "MorphingSwitch")
-            MorphingSwitch(
-                modifier = Modifier
-                    .padding(horizontal = 16.dp),
-                checked = switchValue,
-                onCheckedChange = {
-                    switchValue = it
+            item {
+                Column(
+                    modifier = Modifier.padding(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(text = "ColoredSwitch")
+                    var coloredSwitchValue by rememberSaveable { mutableStateOf(false) }
+                    ColoredSwitch(
+                        checked = coloredSwitchValue,
+                        onCheckedChange = {
+                            coloredSwitchValue = it
+                        },
+                    )
                 }
-            )
-            Spacer(
-                modifier = Modifier.size(16.dp)
-            )
+            }
+            item {
+                Column(
+                    modifier = Modifier.padding(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(text = "ISwitch")
+                    var iSwitchValue by rememberSaveable { mutableStateOf(false) }
+                    ISwitch(
+                        checked = iSwitchValue,
+                        onCheckedChange = {
+                            iSwitchValue = it
+                        },
+                    )
+                }
+            }
+            item {
+                Column(
+                    modifier = Modifier.padding(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(text = "IconISwitch")
+                    var iconISwitchValue by rememberSaveable { mutableStateOf(false) }
+                    IconISwitch(
+                        checked = iconISwitchValue,
+                        onCheckedChange = {
+                            iconISwitchValue = it
+                        },
+                    )
+                }
+            }
+            item(span = { GridItemSpan(2) }) {
+                Column(
+                    modifier = Modifier.padding(8.dp).fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(text = "CustomISwitch")
+                    var customISwitchValue by rememberSaveable { mutableStateOf(false) }
+                    CustomISwitch(
+                        checked = customISwitchValue,
+                        positiveContent = {
+                            Icon(
+                                imageVector = Icons.Default.Done,
+                                contentDescription = null
+                            )
+                        },
+                        negativeContent = {
+                            Text(text = "OFF")
+                        },
+                        onCheckedChange = {
+                            customISwitchValue = it
+                        }
+                    )
+                }
+            }
+            item {
+                Column(
+                    modifier = Modifier.padding(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(text = "CustomSwitch")
+                    var customSwitchValue by rememberSaveable { mutableStateOf(false) }
+                    CustomSwitch(
+                        checked = customSwitchValue,
+                        onCheckedChange = {
+                            customSwitchValue = it
+                        },
+                        positiveContent = {
+                            Icon(
+                                imageVector = Icons.Default.Done,
+                                contentDescription = null,
+                            )
+                        },
+                        negativeContent = {
+                            Text(
+                                "False"
+                            )
+                        }
+                    )
+                }
+            }
+            item {
+                Column(
+                    modifier = Modifier.padding(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(text = "Square Switch")
+                    var squareSwitchValue by rememberSaveable { mutableStateOf(false) }
+                    SquareSwitch(
+                        checked = squareSwitchValue,
+                        onCheckedChange = {
+                            squareSwitchValue = it
+                        }
+                    )
+                }
+            }
+            item {
+                Column(
+                    modifier = Modifier.padding(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(text = "Native Switch")
+                    var nativeSwitchValue by rememberSaveable { mutableStateOf(false) }
+                    NativeSwitch(
+                        checked = nativeSwitchValue,
+                        onCheckedChange = {
+                            nativeSwitchValue = it
+                        }
+                    )
+                }
+            }
+            item {
+                Column(
+                    modifier = Modifier.padding(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(text = "CustomISwitch")
+                    var customISwitchValue by rememberSaveable { mutableStateOf(false) }
+                    CustomISwitch(
+                        checked = customISwitchValue,
+                        positiveContent = {
+                            Icon(
+                                imageVector = Icons.Default.Done,
+                                contentDescription = null
+                            )
+                        },
+                        negativeContent = {
+                            Text(text = "OFF")
+                        },
+                        onCheckedChange = {
+                            customISwitchValue = it
+                        }
+                    )
+                }
+            }
+            item {
+                Column(
+                    modifier = Modifier.padding(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(text = "MorphingSwitch")
+                    var morphingSwitchValue by rememberSaveable { mutableStateOf(false) }
+                    MorphingSwitch(
+                        checked = morphingSwitchValue,
+                        onCheckedChange = {
+                            morphingSwitchValue = it
+                        }
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- replaced the main `Column` with `LazyVerticalGrid` using `GridCells.Adaptive(minSize = 150.dp)` to make the layout responsive.
- Each switch component now manages its own checked state independently, using `rememberSaveable`