### PR TITLE
Refactor JVM NativeSwitch to use SwingPanel with JToggleButton

### DIFF
--- a/switchycompose/multiplatform/build.gradle.kts
+++ b/switchycompose/multiplatform/build.gradle.kts
@@ -61,6 +61,10 @@ kotlin {
                 implementation(compose.uiTest)
             }
         }
+
+        jvmMain.dependencies {
+            implementation(compose.desktop.currentOs)
+        }
     }
 }
 

--- a/switchycompose/multiplatform/src/jvmMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.jvm.kt
+++ b/switchycompose/multiplatform/src/jvmMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.jvm.kt
@@ -1,20 +1,41 @@
 package dev.muazkadan.switchycompose
 
-import androidx.compose.material3.Switch
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.SwingPanel
+import androidx.compose.ui.unit.dp
+import java.awt.event.ItemEvent
+import javax.swing.JToggleButton
 
 @Composable
 actual fun NativeSwitch(
     checked: Boolean,
     onCheckedChange: ((Boolean) -> Unit)?,
     modifier: Modifier,
-    enabled: Boolean
+    enabled: Boolean,
 ) {
-    Switch(
-        checked = checked,
-        onCheckedChange = onCheckedChange,
-        modifier = modifier,
-        enabled = enabled
+    val rememberedListener = remember(onCheckedChange) { onCheckedChange }
+
+    SwingPanel(
+        factory = {
+            JToggleButton().apply {
+                isSelected = checked
+                isEnabled = enabled
+                addItemListener { event ->
+                    if (event.stateChange == ItemEvent.SELECTED || event.stateChange == ItemEvent.DESELECTED) {
+                        rememberedListener?.invoke(isSelected)
+                    }
+                }
+            }
+        },
+        update = { button ->
+            if (button.isSelected != checked) {
+                button.isSelected = checked
+            }
+            button.isEnabled = enabled
+        },
+        modifier = modifier.size(51.dp, 31.dp)
     )
 }


### PR DESCRIPTION
This PR implements the `NativeSwitch` composable for the JVM target using `JToggleButton` from Swing.

- Added `compose.desktop.currentOs` dependency to the `jvmMain` source set.
- The `NativeSwitch` composable now uses `SwingPanel` to embed a `JToggleButton`.
- The `JToggleButton`'s state is synchronized with the `checked` parameter, and its enabled state is controlled by the `enabled` parameter.