### PR TITLE
Enable Js Canvas and add Js target

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
-import org.gradle.kotlin.dsl.implementation
-import org.gradle.kotlin.dsl.project
+@file:OptIn(ExperimentalWasmDsl::class)
+
+import org.gradle.kotlin.dsl.assign
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
@@ -49,10 +50,9 @@ kotlin {
     
     jvm("desktop")
 
-    @OptIn(ExperimentalWasmDsl::class)
-    wasmJs {
-        outputModuleName = "composeApp"
-        browser {
+    listOf(js(), wasmJs()).forEach { target ->
+        target.outputModuleName = "composeApp"
+        target.browser {
             val rootDirPath = project.rootDir.path
             val projectDirPath = project.projectDir.path
             commonWebpackConfig {
@@ -66,7 +66,8 @@ kotlin {
                 }
             }
         }
-        binaries.executable()
+        target.binaries.executable()
+
     }
     
     sourceSets {

--- a/app/src/jsMain/kotlin/dev/muazkadan/switchycomposedemo/main.kt
+++ b/app/src/jsMain/kotlin/dev/muazkadan/switchycomposedemo/main.kt
@@ -1,0 +1,16 @@
+package dev.muazkadan.switchycomposedemo
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.ComposeViewport
+import org.jetbrains.skiko.wasm.onWasmReady
+import kotlinx.browser.document
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    onWasmReady {
+        val body = document.body ?: return@onWasmReady
+        ComposeViewport(body) {
+            App()
+        }
+    }
+}

--- a/app/src/jsMain/resources/index.html
+++ b/app/src/jsMain/resources/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>SwitchyComposeDemo</title>
+        <script src="skiko.js"></script>
+        <style>
+            html,
+            body {
+                width: 100%;
+                height: 100%;
+                margin: 0;
+                padding: 0;
+                overflow: hidden;
+            }
+        </style>
+    </head>
+    <body></body>
+    <script src="composeApp.js"></script>
+</html>

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,4 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.jscanvas.enabled=true

--- a/switchycompose/multiplatform/build.gradle.kts
+++ b/switchycompose/multiplatform/build.gradle.kts
@@ -26,6 +26,8 @@ kotlin {
         }
     }
 
+    js { browser() }
+
     wasmJs { browser() }
 
     listOf(

--- a/switchycompose/multiplatform/src/jsMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.js.kt
+++ b/switchycompose/multiplatform/src/jsMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.js.kt
@@ -1,0 +1,19 @@
+package dev.muazkadan.switchycompose
+
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun NativeSwitch(
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: androidx.compose.ui.Modifier,
+    enabled: Boolean
+) {
+    Switch(
+        checked = checked,
+        onCheckedChange = onCheckedChange,
+        modifier = modifier,
+        enabled = enabled
+    )
+}


### PR DESCRIPTION
This PR enables the experimental Js Canvas feature and adds the Js target to the library.
