### PR TITLE
Update android-minSdk version to 23

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.13.2"
 kotlin = "2.3.0"
 compose-activity = "1.12.2"
-android-minSdk = "21"
+android-minSdk = "23"
 android-compileSdk = "36"
 compose-multiplatform = "1.9.3"
 composeHotReload = "1.1.0-alpha03"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the Android minimum SDK level.
> 
> - Changes `android-minSdk` from `21` to `23` in `gradle/libs.versions.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b18b002bc83e462b8b98f182e7fb2d08c7a0c47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->