### PR TITLE
Update NativeSwitch.ios.kt to use placedAsOverlay in UIKitInteropProp…

### DIFF
--- a/switchycompose/multiplatform/src/iosMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.ios.kt
+++ b/switchycompose/multiplatform/src/iosMain/kotlin/dev/muazkadan/switchycompose/NativeSwitch.ios.kt
@@ -3,6 +3,7 @@ package dev.muazkadan.switchycompose
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.UIKitInteropProperties
@@ -23,7 +24,7 @@ private class SwitchTarget(
     }
 }
 
-@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class, ExperimentalComposeUiApi::class)
 @Composable
 actual fun NativeSwitch(
     checked: Boolean,
@@ -83,8 +84,7 @@ actual fun NativeSwitch(
             }
         },
         properties = UIKitInteropProperties(
-            isInteractive = true,
-            isNativeAccessibilityEnabled = true
+            placedAsOverlay = true,
         )
     )
 }


### PR DESCRIPTION
## What Changed: 
- Update `UIKitInteropProperties` in `NativeSwitch` implementation for iOS to use `placedAsOverlay = true` instead of `isInteractive` and `isNativeAccessibilityEnabled`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates iOS `NativeSwitch` interop configuration.
> 
> - Replaces `UIKitInteropProperties` flags `isInteractive`/`isNativeAccessibilityEnabled` with `placedAsOverlay = true`
> - Adds `ExperimentalComposeUiApi` opt-in required for the new interop property
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b072e4dcb5ef9ae6f0ed7628530955811fed4dfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->